### PR TITLE
old_new_idの処理と洗替処理の変更

### DIFF
--- a/sql/Procedure/old_new_id_merge_second.sql
+++ b/sql/Procedure/old_new_id_merge_second.sql
@@ -2,14 +2,14 @@ CREATE OR REPLACE PROCEDURE `looker_procedure.old_new_id_merge_second`()
 BEGIN
     # 1 2
     # 2 3  
-    # の場合に大きい数の方が真なので、
+    # の場合に
     # 1 3
     # 2 3
     # に洗替する処理
     MERGE looker.old_new_id id1
       USING looker.old_new_id id2
         ON id1.new_ID = id2.old_ID 
-      WHEN MATCHED AND id1.new_ID < id2.new_ID
+      WHEN MATCHED
       THEN
       UPDATE SET
       id1.new_ID = id2.new_ID;

--- a/sql/Procedure/transaction_source_merge.sql
+++ b/sql/Procedure/transaction_source_merge.sql
@@ -8,6 +8,5 @@ BEGIN
     FROM
       `looker.old_new_id` AS id
     WHERE
-      tran.member = id.old_ID
-    AND id.old_ID < id.new_ID;
+      tran.member = id.old_ID;
 END;    


### PR DESCRIPTION
## レビュワー
ca-tanaka-kunitoshi

## 対応isuue 
#1 

## 修正点
・old_new_idの前処理（old_new_id_merge_second.sql）において置き換え前のnew_IDが置き換え後のnew_IDより小さい場合のみ置き換えを行うという条件を削除
・transactionのmemberの洗替処理においてold_ID< new_IDの時のみ洗替を行うという条件を削除

## 実施テスト
old_new_idデータに下記のような、置き換え前のnew_IDが置き換え後のnew_IDより大きい・小さいのふたつのデータを用意し、前処理の変更に問題ないかを確認した。
![image](https://user-images.githubusercontent.com/53036427/112102396-8a5f2a00-8beb-11eb-9378-5d857a67caf7.png)

この際に下記のような洗い替え対象となる4件transactionデータを用意し、洗い替えが行われるかを検証した（purchase_timeが00:00:10のデータが洗い替えされていればold_ID> new_IDでも洗い替えが行われていることが確認できる）。
![image](https://user-images.githubusercontent.com/53036427/112110284-078f9c80-8bf6-11eb-8ea4-e784a8c4c2ba.png)


このふたつのSQLのプロシージャを変更したのちに、Scheduled Queryで実行するプロシージャ（今回変更したSQL以外を含む全体のもの）を実行し、前処理・洗い替え処理の両者が問題ないことを確認

![image](https://user-images.githubusercontent.com/53036427/112102920-5801fc80-8bec-11eb-8c8e-fc7ac5a0c76d.png)


